### PR TITLE
Add System.Threading.Timer-based HTTP client ratelimiting

### DIFF
--- a/src/CyberPatriot.DiscordBot/CyberPatriotDiscordBot.cs
+++ b/src/CyberPatriot.DiscordBot/CyberPatriotDiscordBot.cs
@@ -73,7 +73,11 @@ namespace CyberPatriot.DiscordBot
                 // Scoreboard trial order: live, JSON archive, CSV released archive
                 .AddSingleton<IScoreRetrievalService, FallbackScoreRetrievalService>(prov => new FallbackScoreRetrievalService(
                     prov,
-                    innerProv => Task.FromResult<IScoreRetrievalService>(new HttpScoreboardScoreRetrievalService(innerProv.GetRequiredService<IConfiguration>()["defaultScoreboardHostname"])),
+                    async innerProv => { 
+                        var httpServ = new HttpScoreboardScoreRetrievalService();
+                        await httpServ.InitializeAsync(innerProv);
+                        return httpServ;
+                    },
                     async innerProv =>
                         // if the constructor throws an exception, e.g. missing config, means this provider is skipped
                         new JsonScoreRetrievalService(await System.IO.File.ReadAllTextAsync(innerProv.GetRequiredService<IConfiguration>()["jsonSource"])),

--- a/src/CyberPatriot.DiscordBot/Modules/CyberPatriotCommandModule.cs
+++ b/src/CyberPatriot.DiscordBot/Modules/CyberPatriotCommandModule.cs
@@ -19,53 +19,65 @@ namespace CyberPatriot.DiscordBot.Modules
         [Command("team"), Alias("getteam"), Summary("Gets score information for a given team.")]
         public async Task GetTeamAsync(TeamId teamId)
         {
-            ScoreboardDetails teamScore = await ScoreRetrievalService.GetDetailsAsync(teamId);
-            if (teamScore == null)
+            using (Context.Channel.EnterTypingState())
             {
-                throw new Exception("Error obtaining team score.");
+                ScoreboardDetails teamScore = await ScoreRetrievalService.GetDetailsAsync(teamId);
+                if (teamScore == null)
+                {
+                    throw new Exception("Error obtaining team score.");
+                }
+                await ReplyAsync(string.Empty, embed: ScoreEmbedBuilder.CreateTeamDetailsEmbed(teamScore, await ScoreRetrievalService.GetScoreboardAsync(new ScoreboardFilterInfo(teamScore.Summary.Division, null))).Build());
             }
-            await ReplyAsync(string.Empty, embed: ScoreEmbedBuilder.CreateTeamDetailsEmbed(teamScore, await ScoreRetrievalService.GetScoreboardAsync(new ScoreboardFilterInfo(teamScore.Summary.Division, null))).Build());
         }
 
         [Command("scoreboard"), Alias("leaderboard"), Summary("Returns the current CyberPatriot leaderboard.")]
         public async Task GetLeaderboardAsync(int pageNumber = 1)
         {
-            CompleteScoreboardSummary teamScore = await ScoreRetrievalService.GetScoreboardAsync(ScoreboardFilterInfo.NoFilter);
-            if (teamScore == null)
+            using (Context.Channel.EnterTypingState())
             {
-                throw new Exception("Error obtaining scoreboard.");
+                CompleteScoreboardSummary teamScore = await ScoreRetrievalService.GetScoreboardAsync(ScoreboardFilterInfo.NoFilter);
+                if (teamScore == null)
+                {
+                    throw new Exception("Error obtaining scoreboard.");
+                }
+                await ReplyAsync(ScoreEmbedBuilder.CreateTopLeaderboardEmbed(teamScore, pageNumber: pageNumber, timeZone: await Preferences.GetTimeZoneAsync(Context.Guild, Context.User)));
             }
-            await ReplyAsync(ScoreEmbedBuilder.CreateTopLeaderboardEmbed(teamScore, pageNumber: pageNumber, timeZone: await Preferences.GetTimeZoneAsync(Context.Guild, Context.User)));
         }
 
         [Command("scoreboard"), Alias("leaderboard"), Summary("Returns the current CyberPatriot leaderboard for the given division.")]
         public async Task GetLeaderboardAsync(Division division, int pageNumber = 1)
         {
-            CompleteScoreboardSummary teamScore = await ScoreRetrievalService.GetScoreboardAsync(new ScoreboardFilterInfo(division, null));
-            if (teamScore == null)
+            using (Context.Channel.EnterTypingState())
             {
-                throw new Exception("Error obtaining scoreboard.");
+                CompleteScoreboardSummary teamScore = await ScoreRetrievalService.GetScoreboardAsync(new ScoreboardFilterInfo(division, null));
+                if (teamScore == null)
+                {
+                    throw new Exception("Error obtaining scoreboard.");
+                }
+                await ReplyAsync(ScoreEmbedBuilder.CreateTopLeaderboardEmbed(teamScore, pageNumber: pageNumber, timeZone: await Preferences.GetTimeZoneAsync(Context.Guild, Context.User)));
             }
-            await ReplyAsync(ScoreEmbedBuilder.CreateTopLeaderboardEmbed(teamScore, pageNumber: pageNumber, timeZone: await Preferences.GetTimeZoneAsync(Context.Guild, Context.User)));
         }
 
         [Command("scoreboard"), Alias("leaderboard"), Summary("Returns the current CyberPatriot leaderboard for the given division and tier.")]
         public async Task GetLeaderboardAsync(Division division, string tier, int pageNumber = 1)
         {
-            if (!string.IsNullOrWhiteSpace(tier))
+            using (Context.Channel.EnterTypingState())
             {
-                // transform some common mistakes with the tier
-                // first letter capital
-                char[] tierCharArray = tier.ToCharArray();
-                tierCharArray[0] = char.ToUpper(tierCharArray[0]);
-                tier = new string(tierCharArray);
+                if (!string.IsNullOrWhiteSpace(tier))
+                {
+                    // transform some common mistakes with the tier
+                    // first letter capital
+                    char[] tierCharArray = tier.ToCharArray();
+                    tierCharArray[0] = char.ToUpper(tierCharArray[0]);
+                    tier = new string(tierCharArray);
+                }
+                CompleteScoreboardSummary teamScore = await ScoreRetrievalService.GetScoreboardAsync(new ScoreboardFilterInfo(division, tier));
+                if (teamScore == null)
+                {
+                    throw new Exception("Error obtaining scoreboard.");
+                }
+                await ReplyAsync(ScoreEmbedBuilder.CreateTopLeaderboardEmbed(teamScore, pageNumber: pageNumber, timeZone: await Preferences.GetTimeZoneAsync(Context.Guild, Context.User)));
             }
-            CompleteScoreboardSummary teamScore = await ScoreRetrievalService.GetScoreboardAsync(new ScoreboardFilterInfo(division, tier));
-            if (teamScore == null)
-            {
-                throw new Exception("Error obtaining scoreboard.");
-            }
-            await ReplyAsync(ScoreEmbedBuilder.CreateTopLeaderboardEmbed(teamScore, pageNumber: pageNumber, timeZone: await Preferences.GetTimeZoneAsync(Context.Guild, Context.User)));
         }
     }
 }

--- a/src/CyberPatriot.DiscordBot/Services/ArchivalHttpScoreboardScoreRetrievalService.cs
+++ b/src/CyberPatriot.DiscordBot/Services/ArchivalHttpScoreboardScoreRetrievalService.cs
@@ -1,0 +1,12 @@
+using System;
+using CyberPatriot.Models;
+
+namespace CyberPatriot.DiscordBot.Services
+{
+    public class ArchivalHttpScoreboardScoreRetrievalService : HttpScoreboardScoreRetrievalService
+    {
+        protected override Uri BuildDetailsUri(TeamId team) => new Uri($"https://{Hostname}/cpix/r4_html_scoreboard/{team}.html");
+
+        protected override Uri BuildScoreboardUri(Division? divisionFilter, string tierFilter) => new Uri($"https://{Hostname}/cpix/r4_html_scoreboard/");
+    }
+}

--- a/src/CyberPatriot.DiscordBot/Services/CyberPatriotEventHandlingService.cs
+++ b/src/CyberPatriot.DiscordBot/Services/CyberPatriotEventHandlingService.cs
@@ -39,7 +39,7 @@ namespace CyberPatriot.DiscordBot.Services
             _competitionLogic = competitionLogic;
 
             _discord.MessageReceived += MessageReceived;
-            _teamUrlRegex = new Regex("https?://" + _config["defaultScoreboardHostname"].Replace(".", "\\.") +
+            _teamUrlRegex = new Regex("https?://" + _config["httpConfig:defaultHostname"].Replace(".", "\\.") +
                                       "/team\\.php\\?team=([0-9]{2}-[0-9]{4})");
         }
 

--- a/src/CyberPatriot.DiscordBot/Services/HttpScoreboardScoreRetrievalService.cs
+++ b/src/CyberPatriot.DiscordBot/Services/HttpScoreboardScoreRetrievalService.cs
@@ -9,10 +9,12 @@ using CyberPatriot.Models;
 using HtmlAgilityPack;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using System.Collections.Concurrent;
+using System.Threading;
 
 namespace CyberPatriot.DiscordBot.Services
 {
-    public class HttpScoreboardScoreRetrievalService : IScoreRetrievalService
+    public class HttpScoreboardScoreRetrievalService : IScoreRetrievalService, IDisposable
     {
         public string Hostname { get; private set; }
         protected HttpClient Client { get; }
@@ -22,7 +24,157 @@ namespace CyberPatriot.DiscordBot.Services
         public ScoreFormattingOptions FormattingOptions { get; } = new ScoreFormattingOptions();
         public CompetitionRound Round => _roundInferenceService == null ? 0 : _roundInferenceService.InferRound(DateTimeOffset.UtcNow);
 
+
+
+        // 1 request every 1.5 seconds
+        // note the delay may be up to 3s
+        protected IRateLimitProvider RateLimiter { get; set; } = new TimerRateLimitProvider(1500);
         private ICompetitionRoundLogicService _roundInferenceService = null;
+
+        #region Rate Limiting Implementation
+        protected interface IRateLimitProvider
+        {
+            Task GetWorkAuthorizationAsync();
+            void AddPrerequisite(Task prereq);
+        }
+
+        /// <summary>
+        /// A rate limit provider that performs no limiting.
+        /// </summary>
+        protected class NoneRateLimitProvider : IRateLimitProvider
+        {
+            public Task GetWorkAuthorizationAsync() => Task.CompletedTask;
+            public void AddPrerequisite(Task t) { }
+        }
+
+        /// <summary>
+        /// A rate limit provider backed by a Timer. May have extended delays by up to a factor of two.
+        /// </summary>
+        protected class TimerRateLimitProvider : IRateLimitProvider, IDisposable
+        {
+            // based on https://stackoverflow.com/questions/34792699/async-version-of-monitor-pulse-wait
+            internal sealed class Awaiter
+            {
+                private readonly ConcurrentQueue<TaskCompletionSource<byte>> _waiting = new ConcurrentQueue<TaskCompletionSource<byte>>();
+                private readonly object _syncContext = new object();
+                private volatile ConcurrentBag<Task> _pulsePrerequs = new ConcurrentBag<Task>();
+
+                public void Pulse()
+                {
+                    // this is called from a threadpool thread, we don't mind if we block it
+                    // but if it executes for a while we don't want it to spin up 1000 threads, therefore
+                    // only one thread can be trying to dequeue an awaiter at once
+                    // if another thread comes along while this is still in the lock, it'll silently "fail" and exit
+                    if (Monitor.TryEnter(_syncContext))
+                    {
+                        try
+                        {
+                            // FIXME this feels dreadfully hacky
+                            // should not need to recreate the bag every pulse
+                            var prereqBag = new ConcurrentBag<Task>();
+                            prereqBag = Interlocked.Exchange(ref _pulsePrerequs, prereqBag);
+
+                            // this is the old prereq bag, nobody's modifying it (we've swapped it out)
+                            // wait for all the prereqs, then clear the bag (we don't want a reference to them lying around)
+                            // this is the blocking call that necessitates the lock
+                            Task.WhenAll(prereqBag).Wait();
+                            prereqBag.Clear();
+                            prereqBag = null;
+
+                            // finally complete a waiting task
+                            TaskCompletionSource<byte> tcs;
+                            if (_waiting.TryDequeue(out tcs))
+                            {
+                                tcs.TrySetResult(1);
+                            }
+                        }
+                        finally
+                        {
+                            Monitor.Exit(_syncContext);
+                        }
+                    }
+                }
+
+                public Task Wait()
+                {
+                    // no two awaiters can wait on the same task
+                    /*
+                    TaskCompletionSource<byte> tcs;
+                    if (_waiting.TryPeek(out tcs))
+                    {
+                        return tcs.Task;
+                    }
+                    */
+
+                    var tcs = new TaskCompletionSource<byte>();
+                    _waiting.Enqueue(tcs);
+                    return tcs.Task;
+                }
+
+                public void RegisterPrerequisite(Task t)
+                {
+                    // if we're in the middle of a tick it's ok if the prereq doesn't get awaited this tick
+                    // the lock isn't critical over here
+                    // it's just important it gets awaited before the next Pulse
+                    _pulsePrerequs.Add(t);
+                }
+            }
+
+
+            private Awaiter TaskAwaiter { get; } = new Awaiter();
+            private Timer Timer { get; }
+
+            public TimerRateLimitProvider(TimeSpan interval)
+            {
+                Timer = new Timer(TriggerAwaiter, null, TimeSpan.Zero, interval);
+            }
+
+            public TimerRateLimitProvider(int millis) : this(TimeSpan.FromMilliseconds(millis))
+            {
+            }
+
+            private void TriggerAwaiter(object state = null) => TaskAwaiter.Pulse();
+
+            public Task GetWorkAuthorizationAsync() => TaskAwaiter.Wait();
+
+            public void AddPrerequisite(Task prerequisite) => TaskAwaiter.RegisterPrerequisite(prerequisite);
+
+            #region IDisposable Support
+            private bool disposedValue = false; // To detect redundant calls
+
+            protected virtual void Dispose(bool disposing)
+            {
+                if (!disposedValue)
+                {
+                    if (disposing)
+                    {
+                        Timer.Dispose();
+                    }
+
+                    // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
+                    // TODO: set large fields to null.
+
+                    disposedValue = true;
+                }
+            }
+
+            // TODO: override a finalizer only if Dispose(bool disposing) above has code to free unmanaged resources.
+            // ~TimerRateLimitProvider() {
+            //   // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+            //   Dispose(false);
+            // }
+
+            // This code added to correctly implement the disposable pattern.
+            public void Dispose()
+            {
+                // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+                Dispose(true);
+                // TODO: uncomment the following line if the finalizer is overridden above.
+                // GC.SuppressFinalize(this);
+            }
+            #endregion
+        }
+        #endregion
 
         public HttpScoreboardScoreRetrievalService() : this(null)
         {
@@ -80,7 +232,7 @@ namespace CyberPatriot.DiscordBot.Services
             return builder.Uri;
         }
 
-        protected virtual async Task<HtmlDocument> GetHtmlDocumentForScoreboard(Uri scoreboardUri)
+        protected virtual async Task<string> GetHtmlForScoreboardUri(Uri scoreboardUri)
         {
             string scoreboardPage;
             try
@@ -92,14 +244,16 @@ namespace CyberPatriot.DiscordBot.Services
                 throw new InvalidOperationException("Error getting scoreboard page, perhaps the scoreboard is offline?");
             }
 
-            // potentially cpu-bound
-            return await Task.Run(() =>
+            return scoreboardPage;
+        }
+
+        protected Task<HtmlDocument> ParseHtmlDocumentAsync(string htmlContents) => // potentially cpu-bound
+            Task.Run(() =>
             {
                 HtmlDocument doc = new HtmlDocument();
-                doc.LoadHtml(scoreboardPage);
+                doc.LoadHtml(htmlContents);
                 return doc;
             });
-        }
 
         protected virtual IEnumerable<ScoreboardSummaryEntry> ProcessSummaries(HtmlDocument doc, out DateTimeOffset processTimestamp)
         {
@@ -146,9 +300,14 @@ namespace CyberPatriot.DiscordBot.Services
 
             string detailsPage;
             Uri detailsUri = BuildDetailsUri(team);
+
+            await RateLimiter.GetWorkAuthorizationAsync();
+
+            Task<string> stringTask = Client.GetStringAsync(detailsUri);
+            RateLimiter.AddPrerequisite(stringTask);
             try
             {
-                detailsPage = await Client.GetStringAsync(detailsUri);
+                detailsPage = await stringTask;
                 // hacky, cause they don't return a proper error page for nonexistant teams
                 if (!detailsPage.Contains(@"<div id='chart_div' class='chart'>"))
                 {
@@ -211,8 +370,11 @@ namespace CyberPatriot.DiscordBot.Services
         public virtual async Task<CompleteScoreboardSummary> GetScoreboardAsync(ScoreboardFilterInfo filter)
         {
             Uri scoreboardUri = BuildScoreboardUri(filter.Division, filter.Tier);
+            await RateLimiter.GetWorkAuthorizationAsync();
+            var docTask = GetHtmlForScoreboardUri(scoreboardUri);
+            RateLimiter.AddPrerequisite(docTask);
 
-            var doc = await GetHtmlDocumentForScoreboard(scoreboardUri);
+            var doc = await ParseHtmlDocumentAsync(await docTask);
             var summaries = ProcessSummaries(doc, out DateTimeOffset snapshotTime);
 
             return new CompleteScoreboardSummary()
@@ -223,5 +385,42 @@ namespace CyberPatriot.DiscordBot.Services
                 OriginUri = scoreboardUri
             };
         }
+
+        #region IDisposable Support
+        private bool disposedValue = false; // To detect redundant calls
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    // TODO: dispose managed state (managed objects).
+                    Client.Dispose();
+                    (RateLimiter as IDisposable)?.Dispose();
+                }
+
+                // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
+                // TODO: set large fields to null.
+
+                disposedValue = true;
+            }
+        }
+
+        // TODO: override a finalizer only if Dispose(bool disposing) above has code to free unmanaged resources.
+        // ~HttpScoreboardScoreRetrievalService() {
+        //   // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+        //   Dispose(false);
+        // }
+
+        // This code added to correctly implement the disposable pattern.
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+            Dispose(true);
+            // TODO: uncomment the following line if the finalizer is overridden above.
+            // GC.SuppressFinalize(this);
+        }
+        #endregion
     }
 }


### PR DESCRIPTION
Completely untested!!

Fixes #31. Adds a 1.5s ratelimit to the HTTP scoreboard client. In conjunction with the cache, this should sufficiently limit requests to the backend server.

Also adds a typing indicator while computing scores, but for the vast majority of cases (especially non-CCS backends) that isn't necessary and creates an annoying blip.

Issues:
- Untested!
- HTTP scoreboard requests now *must* wait for the next timer pulse to execute. This is a problem - perhaps there can be a heatmap of sorts which only imposes the rate limit during high request volume.